### PR TITLE
Homedir php patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+apache2 (2.4.25-3ocf2) unstable; urgency=medium
+
+  * Add workaround to get suexec php wrapper working.
+
+ -- Jason Perrin <jvperrin@ocf.berkeley.edu>  Fri, 25 May 2018 13:07:51 -0700
+
 apache2 (2.4.25-3ocf1) unstable; urgency=medium
 
   * Add apache2-suexec-ocf patches.

--- a/debian/patches/ocf-suexec.patch
+++ b/debian/patches/ocf-suexec.patch
@@ -5,7 +5,7 @@
  #define AP_ENVBUF 256
  
 +#define AP_DOC_ROOT "/services"
-+#define AP_SUEXEC_ROOT "/services/http/suexec"
++#define AP_SUEXEC_ROOT "/usr/local/bin/suexec"
 +
  extern char **environ;
  static FILE *log = NULL;

--- a/debian/patches/ocf-suexec.patch
+++ b/debian/patches/ocf-suexec.patch
@@ -1,23 +1,26 @@
 --- a/support/suexec-ocf.c
 +++ b/support/suexec-ocf.c
-@@ -14,6 +14,7 @@
-  * limitations under the License.
-  */
- 
-+
- /*
-  * suexec.c -- "Wrapper" support program for suEXEC behaviour for Apache
-  *
-@@ -69,6 +70,8 @@
+@@ -69,6 +69,9 @@
  
  #define AP_ENVBUF 256
  
 +#define AP_DOC_ROOT "/services"
++#define AP_SUEXEC_ROOT "/services/http/suexec"
 +
  extern char **environ;
  static FILE *log = NULL;
  
-@@ -579,11 +582,15 @@
+@@ -532,7 +535,8 @@
+
+     if (strlen(cwd) > strlen(dwd))
+         strncat(dwd, "/", 1);
+-    if ((strncmp(cwd, dwd, strlen(dwd))) != 0) {
++    if ((strncmp(cwd, dwd, strlen(dwd))) != 0 &&
++        (strncmp(cwd, AP_SUEXEC_ROOT, strlen(AP_SUEXEC_ROOT)) != 0)) {
+         log_err("command not in docroot (%s/%s)\n", cwd, cmd);
+         exit(114);
+     }
+@@ -579,11 +583,18 @@
      /*
       * Error out if the target name/group is different from
       * the name/group of the cwd or the program.
@@ -32,8 +35,11 @@
 +    if (((uid != dir_info.st_uid) ||
 +         (gid != dir_info.st_gid) ||
 +         (uid != prg_info.st_uid) ||
-+         (gid != prg_info.st_gid)
-+        ) && !(dir_info.st_uid == 0 && dir_info.st_gid == 0 && prg_info.st_uid == 0 && prg_info.st_gid == 0)) {
++         (gid != prg_info.st_gid)) &&
++        !((dir_info.st_uid == 0) &&
++          (dir_info.st_gid == 0) &&
++          (prg_info.st_uid == 0) &&
++          (prg_info.st_gid == 0))) {
          log_err("target uid/gid (%lu/%lu) mismatch "
                  "with directory (%lu/%lu) or program (%lu/%lu)\n",
                  (unsigned long)uid, (unsigned long)gid,

--- a/debian/rules
+++ b/debian/rules
@@ -139,14 +139,14 @@ override_dh_install: clean-config-vars prepare-scripts debian/config-dir/apache2
 
 override_dh_fixperms-arch:
 	# standard suexec
-	chmod 4754 debian/apache2-suexec-pristine/usr/lib/apache2/suexec-pristine
 	chgrp www-data debian/apache2-suexec-pristine/usr/lib/apache2/suexec-pristine
+	chmod 4754 debian/apache2-suexec-pristine/usr/lib/apache2/suexec-pristine
 	# configurable suexec
-	chmod 4754 debian/apache2-suexec-custom/usr/lib/apache2/suexec-custom
 	chgrp www-data debian/apache2-suexec-custom/usr/lib/apache2/suexec-custom
+	chmod 4754 debian/apache2-suexec-custom/usr/lib/apache2/suexec-custom
 	# ocf suexec
-	chmod 4754 debian/apache2-suexec-ocf/usr/lib/apache2/suexec-ocf
 	chgrp www-data debian/apache2-suexec-ocf/usr/lib/apache2/suexec-ocf
+	chmod 4754 debian/apache2-suexec-ocf/usr/lib/apache2/suexec-ocf
 	dh_fixperms -a -Xusr/lib/apache2/suexec-custom -Xusr/lib/apache2/suexec-pristine -Xusr/lib/apache2/suexec-ocf
 	chown -R www-data:www-data debian/apache2/var/cache/apache2/mod_cache_disk
 	chown root:adm debian/apache2/var/log/apache2


### PR DESCRIPTION
This essentially allows userdirs to run any commands in `/services/http/suexec`, of which there are only php-cgi wrappers. The problem was that as suexec was, it only allowed for userdirs to execute files in their own home directories, which doesn't work for us, since we'd need to copy the wrapper script we have once for every user. Instead, I just allow an exception for the directory in which we keep our wrapper script so that php can be executed by userdirs. Test files are at [dev-www.o.b.e/~ggroup](https://dev-www.ocf.berkeley.edu/~ggroup/) for the new version and [www.o.b.e/~ggroup](https://www.ocf.berkeley.edu/~ggroup/) for the old version.

I also changed the format of the section in the existing patch that allows running the wrapper script (since it is owned by root), and fixed a bug in the packaging where the setuid bit was cleared in the built package (I think this needs fixing upstream too). Maybe we should make it so the only file that can be executed that is owned by root is in `/services/http/suexec` to be a bit more secure? I don't think it'll make much of a difference though, it gets the user to run it as from the userdir anyway, not from the file being executed.